### PR TITLE
Hwweek24

### DIFF
--- a/homeworks/week24/hw1/src/WebAPI.js
+++ b/homeworks/week24/hw1/src/WebAPI.js
@@ -1,0 +1,98 @@
+import { getAuthToken } from "./utils";
+
+const BASE_URL = "https://student-json-api.lidemy.me";
+
+export const getPosts = () => {
+  return fetch(`${BASE_URL}/posts?_sort=createdAt&_order=desc`).then((res) =>
+    res.json()
+  );
+};
+
+export const getPost = (id) => {
+  return fetch(`${BASE_URL}/posts/${id}?_expand=user`).then((res) =>
+    res.json()
+  );
+};
+
+export const getLimitPost = (page, limit) => {
+  return fetch(
+    `${BASE_URL}/posts?_page=${page}&_limit=${limit}&_sort=createdAt&_order=desc`
+  ).then((res) => res.json());
+};
+
+export const login = (username, password) => {
+  return fetch(`${BASE_URL}/login`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      username,
+      password,
+    }),
+  }).then((res) => res.json());
+};
+
+export const getMe = () => {
+  const token = getAuthToken();
+  return fetch(`${BASE_URL}/me`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  }).then((res) => res.json());
+};
+
+export const postArticle = (title, body) => {
+  const token = getAuthToken();
+  return fetch(`${BASE_URL}/posts`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title,
+      body,
+    }),
+  }).then((res) => res.json());
+};
+
+export const deleteArticle = (id) => {
+  const token = getAuthToken();
+  return fetch(`${BASE_URL}/posts/${id}`, {
+    method: "DELETE",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+  }).then((res) => res.json());
+};
+
+export const editArticle = (id, title, body) => {
+  const token = getAuthToken();
+  return fetch(`${BASE_URL}/posts/${id}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title,
+      body,
+    }),
+  }).then((res) => res.json());
+};
+
+export const register = (nickname, username, password) => {
+  return fetch(`${BASE_URL}/register`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      nickname,
+      username,
+      password,
+    }),
+  }).then((res) => res.json());
+};

--- a/homeworks/week24/hw1/src/components/App/App.js
+++ b/homeworks/week24/hw1/src/components/App/App.js
@@ -1,0 +1,60 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import { HashRouter as Router, Switch, Route } from "react-router-dom";
+import {
+  LoginPage,
+  HomePage,
+  PostPage,
+  AboutMePage,
+  NewPostPage,
+  RegisterPage,
+  EditPage,
+} from "../../pages/";
+import Header from "../Header/";
+import { getUser } from "../../redux/reducers/userReducer";
+import { useDispatch } from "react-redux";
+
+const Root = styled.div`
+  padding-top: 64px;
+`;
+
+function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getUser());
+  }, [dispatch]);
+
+  return (
+    <Root>
+      <Router basename="/w24-react-redux-blog">
+        <Header />
+        <Switch>
+          <Route exact path="/">
+            <HomePage />
+          </Route>
+          <Route path="/register">
+            <RegisterPage />
+          </Route>
+          <Route path="/login">
+            <LoginPage />
+          </Route>
+          <Route path="/post/:id">
+            <PostPage />
+          </Route>
+          <Route path="/newpost">
+            <NewPostPage />
+          </Route>
+          <Route path="/about-me">
+            <AboutMePage />
+          </Route>
+          <Route path="/edit/:id">
+            <EditPage />
+          </Route>
+        </Switch>
+      </Router>
+    </Root>
+  );
+}
+
+export default App;

--- a/homeworks/week24/hw1/src/components/App/App.test.js
+++ b/homeworks/week24/hw1/src/components/App/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders learn react link', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/homeworks/week24/hw1/src/components/App/index.js
+++ b/homeworks/week24/hw1/src/components/App/index.js
@@ -1,0 +1,5 @@
+//import App from "./App";
+//export default App;
+
+// re-export
+export { default } from "./App";

--- a/homeworks/week24/hw1/src/components/Header/Header.js
+++ b/homeworks/week24/hw1/src/components/Header/Header.js
@@ -1,0 +1,125 @@
+import React from "react";
+import styled from "styled-components";
+import { Link, useLocation, useHistory } from "react-router-dom";
+import { setAuthToken } from "../../utils";
+import { setUser } from "../../redux/reducers/userReducer";
+import { useDispatch, useSelector } from "react-redux";
+
+const HeaderContainer = styled.div`
+  height: 64px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  padding: 0px 32px;
+  box-sizing: border-box;
+  background: white;
+`;
+
+const Brand = styled.div`
+  font-size: 32px;
+  font-weight: bold;
+`;
+
+const NavbarList = styled.div`
+  display: flex;
+  align-items: center;
+  height: 64px;
+`;
+
+const Nav = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  box-sizing: border-box;
+  width: 100px;
+  cursor: pointer;
+  color: black;
+  text-decoration: none;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  ${(props) =>
+    props.$active &&
+    `
+  background: rgba(0,0,0,0.1)
+  `};
+`;
+
+const LeftContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  ${NavbarList} {
+    margin-left: 64px;
+  }
+`;
+
+export default function Header() {
+  const location = useLocation();
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const user = useSelector((store) => store.users.user);
+
+  const handleLogout = () => {
+    setAuthToken("");
+    dispatch(setUser(null));
+
+    if (location.pathname !== "/") {
+      history.push("/");
+    }
+  };
+
+  // loading 空白
+  // user 發表 , !loading
+  // !user 註冊, !loading
+
+  // useEffect(() => {
+  //   setIsLoadingHeader(true);
+  //   if (user) {
+  //     setIsLoadingHeader(false);
+  //   }
+  // }, [user]);
+
+  return (
+    <HeaderContainer>
+      <LeftContainer>
+        <Brand>我的第一個部落格</Brand>
+        <NavbarList>
+          <Nav to="/" $active={location.pathname === "/"}>
+            首頁
+          </Nav>
+          <Nav to="/about-me" $active={location.pathname === "/about-me"}>
+            關於我
+          </Nav>
+        </NavbarList>
+      </LeftContainer>
+      <NavbarList>
+        {user ? (
+          <>
+            <Nav to="/newpost" $active={location.pathname === "/newpost"}>
+              發布文章
+            </Nav>
+            <Nav onClick={handleLogout}>登出</Nav>
+          </>
+        ) : (
+          <>
+            <Nav to="/register" $active={location.pathname === "/register"}>
+              註冊
+            </Nav>
+            <Nav to="/login" $active={location.pathname === "/login"}>
+              登入
+            </Nav>
+          </>
+        )}
+      </NavbarList>
+    </HeaderContainer>
+  );
+}

--- a/homeworks/week24/hw1/src/components/Header/index.js
+++ b/homeworks/week24/hw1/src/components/Header/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Header";

--- a/homeworks/week24/hw1/src/components/Pagination/Pagination.js
+++ b/homeworks/week24/hw1/src/components/Pagination/Pagination.js
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { getLimitPost } from "../../WebAPI";
+import { setHomePagePosts } from "../../redux/reducers/postReducer";
+import { useDispatch } from "react-redux";
+
+const PaginationContainer = styled.div`
+  margin: 20px auto;
+  text-align: center;
+`;
+const PageButton = styled.button`
+  border: 0.5px solid #ddd;
+  font-size: 16px;
+  padding: 5px 10px;
+  margin: 0 10px;
+  cursor: pointer;
+  border-radius: 8px;
+  background: ${(props) => props.color};
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.4);
+  }
+`;
+
+export default function Pagination({ pageNumberCount, limit }) {
+  const dispatch = useDispatch();
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const handleClickPage = (page) => {
+    getLimitPost(page, limit).then((posts) =>
+      dispatch(setHomePagePosts(posts))
+    );
+    setCurrentPage(page);
+  };
+
+  return (
+    <PaginationContainer>
+      {pageNumberCount.map((page) => (
+        <PageButton
+          color={
+            currentPage === page ? "rgba(0, 0, 0, 0.4)" : "rgba(0, 0, 0, 0.1)"
+          }
+          onClick={() => handleClickPage(page)}
+        >
+          {page}
+        </PageButton>
+      ))}
+    </PaginationContainer>
+  );
+}
+
+Pagination.propTypes = {
+  setPosts: PropTypes.func,
+  pageNumberCount: PropTypes.array,
+  limit: PropTypes.number,
+};

--- a/homeworks/week24/hw1/src/components/Pagination/index.js
+++ b/homeworks/week24/hw1/src/components/Pagination/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Pagination";

--- a/homeworks/week24/hw1/src/constants/style.js
+++ b/homeworks/week24/hw1/src/constants/style.js
@@ -1,0 +1,2 @@
+export const MEDIA_QUERY_MD = "@media screen and (min-width: 768px)";
+export const MEDIA_QUERY_LG = "@media screen and (min-width: 1000px)";

--- a/homeworks/week24/hw1/src/index.css
+++ b/homeworks/week24/hw1/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/homeworks/week24/hw1/src/index.js
+++ b/homeworks/week24/hw1/src/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./components/App";
+import { Provider } from "react-redux";
+import store from "./redux/store";
+
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById("root")
+);

--- a/homeworks/week24/hw1/src/pages/AboutMePage/AboutMePage.js
+++ b/homeworks/week24/hw1/src/pages/AboutMePage/AboutMePage.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+const AboutMe = styled.div`
+  font-size: 32px;
+  margin: 20px auto;
+  text-align: center;
+`;
+
+export default function AboutMePage() {
+  return (
+    <AboutMe>這是程式導師計畫第四期的 React 部落格作業 by ericcch24</AboutMe>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/AboutMePage/index.js
+++ b/homeworks/week24/hw1/src/pages/AboutMePage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AboutMePage";

--- a/homeworks/week24/hw1/src/pages/EditPage/EditPage.js
+++ b/homeworks/week24/hw1/src/pages/EditPage/EditPage.js
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useHistory, useParams } from "react-router-dom";
+import { getPost, editPost } from "../../redux/reducers/postReducer";
+import { useDispatch, useSelector } from "react-redux";
+
+const NewPostContainer = styled.div`
+  margin: 10px auto;
+  width: 900px;
+  padding: 30px;
+  border: 1px solid black;
+  box-sizing: border-box;
+`;
+
+const NewPostForm = styled.form``;
+
+const NewPostHeader = styled.div`
+  font-size: 20px;
+`;
+
+const NewPostTitle = styled.div`
+  margin-top: 20px;
+`;
+
+const NewPostTitleInput = styled.input`
+  width: 98%;
+  padding: 6px;
+  font-size: 100%;
+  font-family: inherit;
+`;
+
+const NewPostBody = styled.div`
+  margin-top: 30px;
+`;
+
+const NewPostBodyTextarea = styled.textarea`
+  width: 98%;
+  padding: 6px;
+  font-family: inherit;
+  font-size: 100%;
+`;
+
+const NewPostButtonWrapper = styled.div`
+  text-align: right;
+  margin-top: 20px;
+`;
+
+const NewPostButton = styled.button`
+  display: inline-block;
+  cursor: pointer;
+  padding: 10px 30px;
+  font-family: inherit;
+  font-size: 100%;
+`;
+
+const ErrorMessage = styled.div`
+  margin-top: 10px;
+  color: red;
+`;
+
+export default function NewPostPage() {
+  const { id } = useParams();
+  const history = useHistory();
+  const post = useSelector((store) => store.posts.post);
+  const user = useSelector((store) => store.users.user);
+  const [title, setTitle] = useState(post.title);
+  const [body, setBody] = useState(post.body);
+  const [errorMessage, setErrorMessage] = useState();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getPost(id));
+  }, [id, dispatch]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    setErrorMessage(null);
+    if (!title || !body) {
+      return setErrorMessage("請輸入文章標題與內容");
+    }
+    if (!user) {
+      return setErrorMessage("請登入後繼續");
+    }
+
+    dispatch(editPost(id, title, body)).then((newPostResponse) => {
+      if (newPostResponse && newPostResponse.id) {
+        history.push(`/post/${newPostResponse.id}`);
+      }
+    });
+  };
+
+  return (
+    <NewPostContainer>
+      {user ? (
+        <NewPostForm onSubmit={handleSubmit}>
+          <NewPostHeader>發布文章：</NewPostHeader>
+          {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+          <NewPostTitle>
+            <NewPostTitleInput
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+              }}
+              placeholder="輸入文章標題"
+            />
+          </NewPostTitle>
+          <NewPostBody>
+            <NewPostBodyTextarea
+              value={body}
+              onChange={(e) => {
+                setBody(e.target.value);
+              }}
+              placeholder="輸入文章內容"
+              rows={20}
+            />
+          </NewPostBody>
+          <NewPostButtonWrapper>
+            <NewPostButton>送出</NewPostButton>
+          </NewPostButtonWrapper>
+        </NewPostForm>
+      ) : (
+        <ErrorMessage>"請登入後繼續"</ErrorMessage>
+      )}
+    </NewPostContainer>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/EditPage/index.js
+++ b/homeworks/week24/hw1/src/pages/EditPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./EditPage";

--- a/homeworks/week24/hw1/src/pages/HomePage/HomePage.js
+++ b/homeworks/week24/hw1/src/pages/HomePage/HomePage.js
@@ -1,0 +1,72 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import Pagination from "../../components/Pagination/";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  getAllPosts,
+  getHomePagePosts,
+} from "../../redux/reducers/postReducer";
+
+const Root = styled.div`
+  width: 80%;
+  margin: 0 auto;
+`;
+
+const PostContainer = styled.div`
+  border-bottom: 1px solid rgba(0, 12, 34, 0.2);
+  padding: 16px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+`;
+
+const PostTitle = styled(Link)`
+  font-size: 24px;
+  color: #333;
+  text-decoration: none;
+`;
+
+const PostDate = styled.div`
+  color: rgba(0, 0, 0, 0.8);
+`;
+
+function Post({ post }) {
+  return (
+    <PostContainer>
+      <PostTitle to={`/post/${post.id}`}>{post.title}</PostTitle>
+      <PostDate>{new Date(post.createdAt).toLocaleString()}</PostDate>
+    </PostContainer>
+  );
+}
+
+Post.propTypes = {
+  post: PropTypes.object,
+};
+
+export default function HomePage() {
+  const dispatch = useDispatch();
+  const isLoading = useSelector((store) => store.posts.isLoadingPost);
+  const posts = useSelector((store) => store.posts.homePagePosts);
+  const pageNumberCount = useSelector((store) => store.posts.pageNumberCount);
+  const limit = 5;
+
+  useEffect(() => {
+    dispatch(getAllPosts(limit));
+    dispatch(getHomePagePosts(limit));
+  }, [dispatch]);
+
+  return (
+    <Root>
+      {!isLoading && (
+        <>
+          {posts.map((post) => (
+            <Post key={post.id} post={post} />
+          ))}
+          <Pagination pageNumberCount={pageNumberCount} limit={limit} />
+        </>
+      )}
+    </Root>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/HomePage/index.js
+++ b/homeworks/week24/hw1/src/pages/HomePage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./HomePage";

--- a/homeworks/week24/hw1/src/pages/LoginPage/LoginPage.js
+++ b/homeworks/week24/hw1/src/pages/LoginPage/LoginPage.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useHistory, useLocation } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  setIsLoadingUser,
+  setErrorMessage,
+  userLogin,
+  getUser,
+} from "../../redux/reducers/userReducer";
+
+const ErrorMessage = styled.div`
+  color: red;
+`;
+
+export default function LoginPage() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const history = useHistory();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const isLoading = useSelector((store) => store.users.isLoadingUser);
+  const errorMessage = useSelector((store) => store.users.errorMessage);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    dispatch(setErrorMessage(null));
+    if (isLoading) return;
+    dispatch(setIsLoadingUser(true));
+
+    dispatch(userLogin(username, password)).then(() => {
+      if (!localStorage.token) return;
+
+      dispatch(getUser()).then((response) => {
+        if (response.ok === 1) {
+          history.push("/");
+        }
+      });
+    });
+  };
+
+  useEffect(() => {
+    // 每次換頁的時候把 errorMessage 清掉
+    if (location.pathname) {
+      dispatch(setErrorMessage(null));
+    }
+    console.log(location);
+  }, [dispatch, location]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        username:{" "}
+        <input
+          value={username}
+          onChange={(e) => {
+            setUsername(e.target.value);
+          }}
+        />
+      </div>
+      <div>
+        password:{" "}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => {
+            setPassword(e.target.value);
+          }}
+        />
+      </div>
+      <button>登入</button>
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </form>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/LoginPage/index.js
+++ b/homeworks/week24/hw1/src/pages/LoginPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LoginPage";

--- a/homeworks/week24/hw1/src/pages/NewPostPage/NewPostPage.js
+++ b/homeworks/week24/hw1/src/pages/NewPostPage/NewPostPage.js
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useHistory } from "react-router-dom";
+import { newPost } from "../../redux/reducers/postReducer";
+import { useDispatch, useSelector } from "react-redux";
+
+const NewPostContainer = styled.div`
+  margin: 10px auto;
+  width: 900px;
+  padding: 30px;
+  border: 1px solid black;
+  box-sizing: border-box;
+`;
+
+const NewPostForm = styled.form``;
+
+const NewPostHeader = styled.div`
+  font-size: 20px;
+`;
+
+const NewPostTitle = styled.div`
+  margin-top: 20px;
+`;
+
+const NewPostTitleInput = styled.input`
+  width: 98%;
+  padding: 6px;
+  font-size: 100%;
+  font-family: inherit;
+`;
+
+const NewPostBody = styled.div`
+  margin-top: 30px;
+`;
+
+const NewPostBodyTextarea = styled.textarea`
+  width: 98%;
+  padding: 6px;
+  font-family: inherit;
+  font-size: 100%;
+`;
+
+const NewPostButtonWrapper = styled.div`
+  text-align: right;
+  margin-top: 20px;
+`;
+
+const NewPostButton = styled.button`
+  display: inline-block;
+  cursor: pointer;
+  padding: 10px 30px;
+  font-family: inherit;
+  font-size: 100%;
+`;
+
+const ErrorMessage = styled.div`
+  margin-top: 10px;
+  color: red;
+`;
+
+export default function NewPostPage() {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [errorMessage, setErrorMessage] = useState();
+  const history = useHistory();
+  const user = useSelector((store) => store.users.user);
+
+  const dispatch = useDispatch();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setErrorMessage(null);
+    if (!title || !body) {
+      return setErrorMessage("請輸入文章標題與內容");
+    }
+    if (!user) {
+      return setErrorMessage("請登入後繼續");
+    }
+
+    dispatch(newPost(title, body)).then((newPostResponse) => {
+      if (newPostResponse && newPostResponse.id) {
+        history.push(`/post/${newPostResponse.id}`);
+      }
+    });
+  };
+
+  return (
+    <NewPostContainer>
+      {user ? (
+        <NewPostForm onSubmit={handleSubmit}>
+          <NewPostHeader>發布文章：</NewPostHeader>
+          {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+          <NewPostTitle>
+            <NewPostTitleInput
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+              }}
+              placeholder="輸入文章標題"
+            />
+          </NewPostTitle>
+          <NewPostBody>
+            <NewPostBodyTextarea
+              value={body}
+              onChange={(e) => {
+                setBody(e.target.value);
+              }}
+              placeholder="輸入文章內容"
+              rows={20}
+            />
+          </NewPostBody>
+          <NewPostButtonWrapper>
+            <NewPostButton>送出</NewPostButton>
+          </NewPostButtonWrapper>
+        </NewPostForm>
+      ) : (
+        <ErrorMessage>"請登入後繼續"</ErrorMessage>
+      )}
+    </NewPostContainer>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/NewPostPage/index.js
+++ b/homeworks/week24/hw1/src/pages/NewPostPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NewPostPage";

--- a/homeworks/week24/hw1/src/pages/PostPage/PostPage.js
+++ b/homeworks/week24/hw1/src/pages/PostPage/PostPage.js
@@ -1,0 +1,109 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { Link, useParams, useHistory } from "react-router-dom";
+import { getPost, deletePost } from "../../redux/reducers/postReducer";
+import { useDispatch, useSelector } from "react-redux";
+
+const Root = styled.div`
+  width: 60%;
+  margin: 0 auto;
+`;
+
+const PostContainer = styled.div`
+  border: 1px solid #333;
+  padding: 10px 15px;
+`;
+
+const PostTitle = styled.div`
+  font-size: 26px;
+`;
+
+const PostDate = styled.div`
+  border-bottom: 1px solid #333;
+  margin: 10px 0px;
+  font-size: 14px;
+`;
+
+const PostBody = styled.div`
+  word-break: break-word;
+  font-size: 18px;
+  margin-top: 15px;
+`;
+
+const ButtonWrapper = styled.div`
+  text-align: right;
+  margin-top: 20px;
+`;
+
+const DeleteButton = styled.button`
+  cursor: pointer;
+`;
+
+const EditButton = styled.button`
+  cursor: pointer;
+  margin-right: 5px;
+  padding: 1px;
+`;
+
+const EditLink = styled(Link)`
+  box-sizing: border-box;
+  text-decoration: none;
+  color: black;
+  padding: 4px 5px;
+`;
+
+function Post({ post, handleDelete, user }) {
+  return (
+    <PostContainer>
+      <PostTitle>{post.title}</PostTitle>
+      <PostDate>{new Date(post.createdAt).toLocaleString()}</PostDate>
+      <PostBody>{post.body}</PostBody>
+      {user ? (
+        <ButtonWrapper>
+          <EditButton>
+            <EditLink to={`/edit/${post.id}`}>編輯</EditLink>
+          </EditButton>
+          <DeleteButton onClick={handleDelete}>刪除</DeleteButton>
+        </ButtonWrapper>
+      ) : (
+        ""
+      )}
+    </PostContainer>
+  );
+}
+
+Post.propTypes = {
+  post: PropTypes.object,
+};
+
+export default function PostPage() {
+  const { id } = useParams();
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const isLoading = useSelector((store) => store.posts.isLoadingPost);
+  const post = useSelector((store) => store.posts.post);
+  const user = useSelector((store) => store.users.user);
+
+  const handleDelete = (e) => {
+    e.preventDefault();
+
+    dispatch(deletePost(id)).then(() => {
+      history.push("/");
+    });
+  };
+
+  useEffect(() => {
+    dispatch(getPost(id));
+  }, [id, dispatch]);
+
+  return (
+    <Root>
+      {!isLoading && post ? (
+        <Post post={post} handleDelete={handleDelete} user={user} />
+      ) : (
+        ""
+      )}
+    </Root>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/PostPage/index.js
+++ b/homeworks/week24/hw1/src/pages/PostPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PostPage";

--- a/homeworks/week24/hw1/src/pages/RegisterPage/RegisterPage.js
+++ b/homeworks/week24/hw1/src/pages/RegisterPage/RegisterPage.js
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useHistory, useLocation } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  setIsLoadingUser,
+  setErrorMessage,
+  userRegister,
+  getUser,
+} from "../../redux/reducers/userReducer";
+
+const ErrorMessage = styled.div`
+  color: red;
+`;
+
+export default function RegisterPage() {
+  const [nickname, setNickname] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const location = useLocation();
+  const isLoading = useSelector((store) => store.users.isLoadingUser);
+  const errorMessage = useSelector((store) => store.users.errorMessage);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    dispatch(setErrorMessage(null));
+    if (isLoading) return;
+    dispatch(setIsLoadingUser(true));
+
+    dispatch(userRegister(nickname, username, password)).then(() => {
+      if (!localStorage.token) return;
+
+      dispatch(getUser()).then((response) => {
+        if (response.ok === 1) {
+          history.push("/");
+        }
+      });
+    });
+  };
+
+  useEffect(() => {
+    // 每次換頁的時候把 errorMessage 清掉
+    if (location.pathname) {
+      dispatch(setErrorMessage(null));
+    }
+  }, [dispatch, location]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        nickname:{" "}
+        <input
+          value={nickname}
+          onChange={(e) => {
+            setNickname(e.target.value);
+          }}
+        />
+      </div>
+      <div>
+        username:{" "}
+        <input
+          value={username}
+          onChange={(e) => {
+            setUsername(e.target.value);
+          }}
+        />
+      </div>
+      <div>
+        password:{" "}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => {
+            setPassword(e.target.value);
+          }}
+        />
+      </div>
+      <button>註冊</button>
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+    </form>
+  );
+}

--- a/homeworks/week24/hw1/src/pages/RegisterPage/index.js
+++ b/homeworks/week24/hw1/src/pages/RegisterPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./RegisterPage";

--- a/homeworks/week24/hw1/src/pages/index.js
+++ b/homeworks/week24/hw1/src/pages/index.js
@@ -1,0 +1,17 @@
+import LoginPage from "./LoginPage";
+import HomePage from "./HomePage";
+import PostPage from "./PostPage";
+import AboutMePage from "./AboutMePage";
+import NewPostPage from "./NewPostPage";
+import RegisterPage from "./RegisterPage";
+import EditPage from "./EditPage";
+
+export {
+  LoginPage,
+  HomePage,
+  PostPage,
+  AboutMePage,
+  NewPostPage,
+  RegisterPage,
+  EditPage,
+};

--- a/homeworks/week24/hw1/src/redux/reducers/postReducer.js
+++ b/homeworks/week24/hw1/src/redux/reducers/postReducer.js
@@ -1,0 +1,102 @@
+import { createSlice } from "@reduxjs/toolkit";
+import {
+  getPost as getPostAPI,
+  postArticle,
+  editArticle,
+  getPosts,
+  getLimitPost,
+  deleteArticle,
+} from "../../WebAPI";
+
+export const postReducer = createSlice({
+  name: "posts",
+  initialState: {
+    isLoadingPost: false,
+    post: null,
+    newPostResponse: null,
+    homePagePosts: [],
+    pageNumberCount: [],
+  },
+  reducers: {
+    setIsLoadingPost: (state, action) => {
+      state.isLoadingPost = action.payload;
+    },
+
+    setPost: (state, action) => {
+      state.post = action.payload;
+    },
+
+    setNewPostResponse: (state, action) => {
+      state.newPostResponse = action.payload;
+    },
+
+    setHomePagePosts: (state, action) => {
+      state.homePagePosts = action.payload;
+    },
+
+    setPageNumberCount: (state, action) => {
+      state.pageNumberCount = action.payload;
+    },
+  },
+});
+
+export const {
+  setIsLoadingPost,
+  setPost,
+  setNewPostResponse,
+  setHomePagePosts,
+  setPageNumberCount,
+} = postReducer.actions;
+
+export const getPost = (id) => (dispatch) => {
+  dispatch(setIsLoadingPost(true));
+  getPostAPI(id)
+    .then((res) => {
+      dispatch(setPost(res));
+      dispatch(setIsLoadingPost(false));
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+};
+
+export const newPost = (title, body) => (dispatch) => {
+  // 可以變成 promise 傳遞
+  return postArticle(title, body).then((res) => {
+    dispatch(setNewPostResponse(res));
+    return res;
+  });
+};
+
+export const editPost = (id, title, body) => (dispatch) => {
+  return editArticle(id, title, body).then((res) => {
+    dispatch(setNewPostResponse(res));
+    return res;
+  });
+};
+
+export const getAllPosts = (limit) => (dispatch) => {
+  getPosts().then((posts) => {
+    const allPages = Math.ceil(posts.length / limit);
+    dispatch(
+      setPageNumberCount(Array.from({ length: allPages }, (_, i) => i + 1))
+    );
+  });
+};
+
+export const getHomePagePosts = (limit) => (dispatch) => {
+  dispatch(setIsLoadingPost(true));
+
+  getLimitPost(1, limit).then((posts) => {
+    dispatch(setHomePagePosts(posts));
+    dispatch(setIsLoadingPost(false));
+  });
+};
+
+export const deletePost = (id) => (dispatch) => {
+  return deleteArticle(id).then((res) => {
+    return res;
+  });
+};
+
+export default postReducer.reducer;

--- a/homeworks/week24/hw1/src/redux/reducers/userReducer.js
+++ b/homeworks/week24/hw1/src/redux/reducers/userReducer.js
@@ -1,0 +1,70 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { login, register, getMe } from "../../WebAPI";
+import { setAuthToken } from "../../utils";
+
+export const userReducer = createSlice({
+  name: "users",
+  initialState: {
+    user: null,
+    isLoadingUser: false,
+    errorMessage: null,
+  },
+  reducers: {
+    setUser: (state, action) => {
+      state.user = action.payload;
+    },
+
+    setIsLoadingUser: (state, action) => {
+      state.isLoadingUser = action.payload;
+    },
+
+    setErrorMessage: (state, action) => {
+      state.errorMessage = action.payload;
+    },
+  },
+});
+
+export const {
+  setUser,
+  setIsLoadingUser,
+  setErrorMessage,
+} = userReducer.actions;
+
+export const userLogin = (username, password) => (dispatch) => {
+  return login(username, password).then((data) => {
+    dispatch(setIsLoadingUser(false));
+    if (data.ok === 0) {
+      return dispatch(setErrorMessage(data.message));
+    }
+    setAuthToken(data.token);
+    return data;
+  });
+};
+
+export const userRegister = (nickname, username, password) => (dispatch) => {
+  return register(nickname, username, password).then((data) => {
+    dispatch(setIsLoadingUser(false));
+    if (data.ok === 0) {
+      return dispatch(setErrorMessage(data.message));
+    }
+    setAuthToken(data.token);
+    return data;
+  });
+};
+
+export const getUser = () => (dispatch) => {
+  return getMe()
+    .then((response) => {
+      if (response.ok !== 1) {
+        setAuthToken("");
+        return dispatch(setErrorMessage(response.toString()));
+      }
+      dispatch(setUser(response.data));
+      return response;
+    })
+    .catch((err) => {
+      return dispatch(setErrorMessage(err));
+    });
+};
+
+export default userReducer.reducer;

--- a/homeworks/week24/hw1/src/redux/store.js
+++ b/homeworks/week24/hw1/src/redux/store.js
@@ -1,0 +1,10 @@
+import { configureStore } from "@reduxjs/toolkit";
+import postReducer from "./reducers/postReducer";
+import userReducer from "./reducers/userReducer";
+
+export default configureStore({
+  reducer: {
+    posts: postReducer,
+    users: userReducer,
+  },
+});

--- a/homeworks/week24/hw1/src/reportWebVitals.js
+++ b/homeworks/week24/hw1/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = onPerfEntry => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;

--- a/homeworks/week24/hw1/src/setupTests.js
+++ b/homeworks/week24/hw1/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/homeworks/week24/hw1/src/utils.js
+++ b/homeworks/week24/hw1/src/utils.js
@@ -1,0 +1,9 @@
+const TOKEN_NAME = "token";
+
+export const setAuthToken = (token) => {
+  return localStorage.setItem(TOKEN_NAME, token);
+};
+
+export const getAuthToken = () => {
+  return localStorage.getItem(TOKEN_NAME);
+};

--- a/homeworks/week24/hw2.md
+++ b/homeworks/week24/hw2.md
@@ -1,12 +1,29 @@
 ## Redux middleware 是什麼？
 
+- 在 action dispatch 後，進到 store 之前，Redux middleware 會負責將 action 經過一些處理再傳到 store（例如拿 API 資料等非同步操作）。
+  例如當 action 是 function 而非物件時，Redux thunk 這個 middleware 就會就會先執行 dispatch 過來的 function，再傳往 store。
 
 ## CSR 跟 SSR 差在哪邊？為什麼我們需要 SSR？
 
+- Client Side Render: 瀏覽器除了請求 HTML 之外也要等待請求 JS，還要等 React 處理網頁的內容（例如請求 API、將 component 放到 DOM 上），最後使用者才會看到完整的網頁內容。
+
+* Server Side Render: 在第一次 render 時，網頁的內容會在 Server 端就處理完成，使用者就會先看到一個完整的網頁內容，而後續的頁面操作一樣交由 Javascript 處理。
+
+* 兩者主要差別就是 SSR 在第一次 render 畫面時是由後端 server 處理。
+
+* SSR 的優點在於因為在第一次 render 時網頁的完整內容就已經載入，因此有利於 SEO 的搜尋，也因為少了要等待請求 HTML 與 JS 的動作，而讓使用者從請求後到看見完整網頁的時間相較 CSR 有所減少。
 
 ## React 提供了哪些原生的方法讓你實作 SSR？
 
+- SSR 實際 render 頁面的方式是向渲染伺服器請求 HTML，渲染伺服器會將 HTML 以字串的形式回傳，瀏覽器再解析其內容並呈現畫面。而 React 的 ReactDOMServer 提供了 `renderToString()` 的方法將 component 轉換成 HTML 字串，就可以在第一次 render 時從伺服器端產生 HTML。
+
+* ReactDOMServer 另外還有提供以下方法：
+  `renderToStaticMarkup()`: 與 `renderToString()` 類似，差別在於只適用於靜態網頁，無法讓頁面有互動性。
+  `renderToNodeStream()`: 此方法會回傳一個 Readable Stream(只能在伺服器端使用)，然後輸出 HTML 字串。
+  `renderToStaticNodeStream()`: 與 `renderToNodeStream()` 類似，差別在於只適用於靜態網頁，無法讓頁面有互動性。
 
 ## 承上，除了原生的方法，有哪些現成的框架或是工具提供了 SSR 的解決方案？至少寫出兩種
 
+- Next.js: 內建 SSR 機制。
 
+* Prerender: 將 Js 檔案 render 的內容存成靜態 HTML，搜尋引擎就可以爬到該 HTML 內容。


### PR DESCRIPTION
[Redux 部落格](https://ericcch24.github.io/react-redux-blog/)

老師好：這次作業有以下兩個問題：

* `login` 跟 `register` 的頁面在重整的時候不知道為什麼一定會打 `getMe` 的 API，就會印出錯誤，但我程式明明是寫在 submit 的時候才會打 API，不知道為什麼重整就會觸發到＠＠


* `header` 會根據 user 的狀態在右半邊顯示發表還是註冊等等，但是在頁面重整的時還沒拿到 user 的時候就會先顯示註冊登入，所以我想說去設定當頁面還在 loading 的時候 header 右半邊先空白，而我想到的方法是用 `useEffect` 去改 loading 的 state ，但是好像都需要跟 user 綁在一起(像`Header.js`中註解)，結果就變成登出之後因為沒有 user 導致 header 右半邊就會直接空白，不知道老師有沒有建議什麼解決辦法QQ

謝謝老師